### PR TITLE
deleting seed configurations in dbt_project.yml

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -24,10 +24,6 @@ clean-targets:
 vars:
   "dbt_date:time_zone": "America/Los_Angeles"
 
-seeds:
-  jaffle_shop:
-    +schema: raw
-
 models:
   jaffle_shop:
     staging:


### PR DESCRIPTION
seed configurations need to be deleted because they are throwing warnings because we do not have seeds in our project